### PR TITLE
Improve cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.15)
 
 project(audioServer)
 
@@ -9,400 +9,211 @@ message("server build")
 # we use boost information from cmake -DBOOST_DIR
 if (BOOST_DIR)
   set(Boost_NO_BOOST_CMAKE ON)
-  set(BOOST_ROOT ${BOOST_DIR})
+  set(BOOST_ROOT ${BOOST_DIR}) # This can be also set via cmake -DBOOST_ROOT=...
   message(STATUS "Boost root dir set to ${BOOST_ROOT}")
 endif (BOOST_DIR)
 
-if (WITH_UNREADABLE)
-    set(UNREADABLE WITH_UNREADABLE)
-endif ()
+# Required dependencies on ubuntu: atp install libboost-filesystem-dev libboost-regex-dev libtag1-dev libgstreamer1.0-dev nlohmann-json3-dev
 
-find_package( Threads REQUIRED)
-find_package( Boost 1.70.0 REQUIRED COMPONENTS filesystem system regex locale)
-
-message( STATUS "Boost version from version file is ${Boost_VERSION}" )
-message( STATUS "Boost include dir is ${Boost_INCLUDE_DIRS}" )
-message( STATUS "Boost library dir is ${Boost_LIBRARIES}" )
-
-find_path(
-    SNCCLIENT_INCLUDE_DIRS
-    PATH_SUFFIXES snc
-    NAMES config.h client.h
-)
-# did not find a way to add a path suffix to base paths (e.g. bitbake do specifies a lot here)
-# therefor this strange construction. Please let me know, if this is more easy!!!
-SET (SNCCLIENT_INCLUDE_DIRS "${SNCCLIENT_INCLUDE_DIRS}/snc" )
-
-
-find_library (
-    SNCCLIENT_LIBRARIES
-    NAMES snc_client
+find_package(snc QUIET CONFIG)
+if(NOT snc_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+      snc
+      GIT_REPOSITORY https://github.com/Bjoe/snc.git
+      GIT_TAG        improve-cmake
     )
+    FetchContent_MakeAvailable(snc)
+endif()
+
+find_package(Threads REQUIRED)
+find_package(Boost 1.70.0 REQUIRED COMPONENTS filesystem regex)
+find_package(nlohmann_json REQUIRED)
 
 include(createdirs)
 include(FindPkgConfig)
 
-pkg_search_module(TagLib REQUIRED taglib)
+pkg_search_module(TagLib REQUIRED IMPORTED_TARGET taglib)
+pkg_check_modules(GST REQUIRED IMPORTED_TARGET gstreamer-1.0)
 
-pkg_check_modules(GST REQUIRED gstreamer-1.0)
 
-set(PLAYERINTERFACE
-    ${CMAKE_SOURCE_DIR}/playerinterface/Player.h
-    ${CMAKE_SOURCE_DIR}/playerinterface/Player.cpp
-    ${CMAKE_SOURCE_DIR}/playerinterface/mpvplayer.h
-    ${CMAKE_SOURCE_DIR}/playerinterface/mpvplayer.cpp
-    ${CMAKE_SOURCE_DIR}/playerinterface/gstplayer.h
-    ${CMAKE_SOURCE_DIR}/playerinterface/gstplayer.cpp
-    )
+add_library(common)
+add_subdirectory(common)
+target_compile_features(common PUBLIC cxx_std_17)
+target_compile_definitions(common PUBLIC BOOST_BEAST_USE_STD_STRING_VIEW)
+target_include_directories(common
+  PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
 
-set(WEBSERVER
-    ${CMAKE_SOURCE_DIR}/common/Constants.h
-    ${CMAKE_SOURCE_DIR}/webserver/Listener.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/Listener.h
-    ${CMAKE_SOURCE_DIR}/webserver/sessionhandler.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/sessionhandler.h
-    ${CMAKE_SOURCE_DIR}/webserver/Session.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/Session.h
-    ${CMAKE_SOURCE_DIR}/webserver/databaseaccess.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/databaseaccess.h
-    ${CMAKE_SOURCE_DIR}/webserver/playlistaccess.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/playlistaccess.h
-    ${CMAKE_SOURCE_DIR}/webserver/playeraccess.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/playeraccess.h
-    ${CMAKE_SOURCE_DIR}/webserver/wifiaccess.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/wifiaccess.h
-    ${CMAKE_SOURCE_DIR}/webserver/websocketsession.cpp
-    ${CMAKE_SOURCE_DIR}/webserver/websocketsession.h
-    )
 
-set(ID3INTERFACE
-    ${CMAKE_SOURCE_DIR}/id3tagreader/Id3Info.h
-    ${CMAKE_SOURCE_DIR}/id3tagreader/id3TagReader.cpp
-    ${CMAKE_SOURCE_DIR}/id3tagreader/id3TagReader.h
-    ${CMAKE_SOURCE_DIR}/id3tagreader/idtag.cpp
-    ${CMAKE_SOURCE_DIR}/id3tagreader/idtag.h
-    )
+add_library(id3tagreader)
+add_subdirectory(id3tagreader)
+target_compile_features(id3tagreader PUBLIC cxx_std_17)
+target_include_directories(id3tagreader
+  PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+target_link_libraries(id3tagreader
+    PUBLIC
+    nlohmann_json::nlohmann_json
+    Boost::filesystem
+    PkgConfig::TagLib
+)
 
-set(WIFI
-    ${CMAKE_SOURCE_DIR}/wifi/wifi.h
-    ${CMAKE_SOURCE_DIR}/wifi/wifi.cpp
-    )
 
-set(DATABASE
-    ${CMAKE_SOURCE_DIR}/database/NameType.h
-    ${CMAKE_SOURCE_DIR}/database/searchitem.h
-    ${CMAKE_SOURCE_DIR}/database/searchaction.h
-    ${CMAKE_SOURCE_DIR}/database/playlist.cpp
-    ${CMAKE_SOURCE_DIR}/database/playlist.h
-    ${CMAKE_SOURCE_DIR}/database/id3repository.cpp
-    ${CMAKE_SOURCE_DIR}/database/id3repository.h
-    ${CMAKE_SOURCE_DIR}/database/playlistcontainer.cpp
-    ${CMAKE_SOURCE_DIR}/database/playlistcontainer.h
-    ${CMAKE_SOURCE_DIR}/database/SimpleDatabase.cpp
-    ${CMAKE_SOURCE_DIR}/database/SimpleDatabase.h
-    ${CMAKE_SOURCE_DIR}/database/songtagreader.cpp
-    ${CMAKE_SOURCE_DIR}/database/songtagreader.h
-    )
 
-set(COMMONCOMPONENTS
-    ${CMAKE_SOURCE_DIR}/common/Constants.cpp
-    ${CMAKE_SOURCE_DIR}/common/Constants.h
-    ${CMAKE_SOURCE_DIR}/common/logger.h
-    ${CMAKE_SOURCE_DIR}/common/logger.cpp
-    ${CMAKE_SOURCE_DIR}/common/Extractor.h
-    ${CMAKE_SOURCE_DIR}/common/mime_type.cpp
-    ${CMAKE_SOURCE_DIR}/common/mime_type.h
-    ${CMAKE_SOURCE_DIR}/common/NameGenerator.h
-    ${CMAKE_SOURCE_DIR}/common/NameGenerator.cpp
-    ${CMAKE_SOURCE_DIR}/common/urlDecode.h
-    ${CMAKE_SOURCE_DIR}/common/urlDecode.c
-    ${CMAKE_SOURCE_DIR}/common/repeattimer.cpp
-    ${CMAKE_SOURCE_DIR}/common/repeattimer.h
-    ${CMAKE_SOURCE_DIR}/common/filesystemadditions.cpp
-    ${CMAKE_SOURCE_DIR}/common/filesystemadditions.h
-    ${CMAKE_SOURCE_DIR}/common/FileType.h
-    ${CMAKE_SOURCE_DIR}/common/generalPlaylist.h
-    ${CMAKE_SOURCE_DIR}/common/stringmanipulator.cpp
-    ${CMAKE_SOURCE_DIR}/common/stringmanipulator.h
-    ${CMAKE_SOURCE_DIR}/common/albumlist.h
-    ${CMAKE_SOURCE_DIR}/common/hash.cpp
-    ${CMAKE_SOURCE_DIR}/common/hash.h
-    ${CMAKE_SOURCE_DIR}/common/base64.cpp
-    ${CMAKE_SOURCE_DIR}/common/base64.h
-    )
+add_library(database)
+add_subdirectory(database)
+target_compile_features(database PUBLIC cxx_std_17)
+target_include_directories(database
+  PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+target_link_libraries(database PUBLIC id3tagreader)
 
-add_executable(${PROJECT_NAME}
-               ${CMAKE_SOURCE_DIR}/audioserver/audioServer.cpp
-               ${PLAYERINTERFACE}
-               ${WEBSERVER}
-               ${ID3INTERFACE}
-               ${DATABASE}
-               ${WIFI}
-               ${COMMONCOMPONENTS}
-               )
+
+
+
+
+
+add_library(playerinterface)
+add_subdirectory(playerinterface)
+target_compile_features(playerinterface PUBLIC cxx_std_17)
+target_include_directories(playerinterface
+  PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+target_link_libraries(playerinterface PUBLIC PkgConfig::GST)
+
+
+add_executable(${PROJECT_NAME})
+
+add_subdirectory(audioserver)
+add_subdirectory(webserver)
+add_subdirectory(wifi)
+
 
 target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        database
+        playerinterface
+        common
+        snc::snc_client
+        Boost::regex
+        Boost::headers
         Threads::Threads
-        ${Boost_LIBRARIES}
-        ${TagLib_LIBRARIES}
-        ${GST_LIBRARIES}
-        ${SNCCLIENT_LIBRARIES}
 )
-
-target_include_directories(
-	${PROJECT_NAME}
-	PUBLIC
-        ${CMAKE_SOURCE_DIR}
-        ${GST_INCLUDE_DIRS}
-        ${Boost_INCLUDE_DIRS}
-        ${TagLib_INCLUDE_DIRS}
-        ${SNCCLIENT_INCLUDE_DIRS}
-)
-message("snc lib include is ${SNCCLIENT_INCLUDE_DIRS}")
-
-message("snc lib include is ${SNCCLIENT_LIBRARIES}")
-
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "audioServer")
-#target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic -O0 -g)
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic -O2)
-target_compile_definitions(${PROJECT_NAME} PUBLIC BOOST_BEAST_USE_STD_STRING_VIEW ${UNREADABLE})
+if (WITH_UNREADABLE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC WITH_UNREADABLE)
+endif ()
 
 
-
-add_executable(ituneJsonConverter itunesJsonConverter/itunesJsonConverter.cpp ${COMMONCOMPONENTS})
-set_target_properties(ituneJsonConverter PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-target_compile_options(ituneJsonConverter PRIVATE -Wall -Wextra -pedantic )
-target_include_directories(
-        ituneJsonConverter
-        PUBLIC
-        ${CMAKE_SOURCE_DIR}
-        ${Boost_INCLUDE_DIRS}
-)
+add_executable(ituneJsonConverter)
+add_subdirectory(itunesJsonConverter)
 target_link_libraries(
     ituneJsonConverter
+    PUBLIC
+        common
+        nlohmann_json::nlohmann_json
+        Boost::headers
         Threads::Threads
-        ${Boost_LIBRARIES}
 )
 
-add_executable(wpa_generator
-               wpa_generator/wpa_generator.cpp
-)
-
-target_link_libraries(wpa_generator
-        Threads::Threads
-        ${Boost_LIBRARIES}
-)
-
-target_include_directories(
-        wpa_generator
-        PUBLIC
-        ${CMAKE_SOURCE_DIR}
-        ${Boost_INCLUDE_DIRS}
+add_executable(wpaGenerator)
+add_subdirectory(wpa_generator)
+target_compile_features(wpaGenerator PUBLIC cxx_std_17)
+target_link_libraries(wpaGenerator
+    PUBLIC
+    nlohmann_json::nlohmann_json
+    Boost::headers
+    Threads::Threads
 )
 
 
 if (WITH_ADD)
 
-    add_executable( mp3CoverExtractor ${CMAKE_SOURCE_DIR}/extractId3Cover/saveID3TagPicture.cpp ${COMMONCOMPONENTS})
-    set_target_properties(mp3CoverExtractor PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-
-    target_include_directories(
-            mp3CoverExtractor
-            PUBLIC
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-            ${TagLib_INCLUDE_DIRS}
-    )
-
+    add_executable( mp3CoverExtractor)
+    add_subdirectory(extractId3Cover)
     target_link_libraries(
             mp3CoverExtractor
-            Threads::Threads
-            ${Boost_LIBRARIES}
-            ${TagLib_LIBRARIES}
-    )
-
-    add_executable( uniqueNameGenerator ${CMAKE_SOURCE_DIR}/test/uniqueNameGenerator.cpp ${COMMONCOMPONENTS})
-    set_target_properties(uniqueNameGenerator PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-
-    target_include_directories(
-            uniqueNameGenerator
             PUBLIC
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-            ${TagLib_INCLUDE_DIRS}
+            common
+            PkgConfig::TagLib
+            Boost::filesystem
+            Boost::headers
+            Threads::Threads
     )
+
+    add_executable( uniqueNameGenerator)
+    add_executable( databaseTest)
+    add_executable( playerCmdl)
+    add_executable( loggerTest)
+    add_executable( repeatTimerTest)
+    add_executable( mpvTest)
+    add_executable( gstTest)
+    add_executable( urlTest)
+
+    add_subdirectory(test)
 
     target_link_libraries(
             uniqueNameGenerator
-            Threads::Threads
-            ${Boost_LIBRARIES}
-            ${TagLib_LIBRARIES}
-    )
-
-
-    add_executable( databaseTest ${DATABASE} ${ID3INTERFACE} ${COMMONCOMPONENTS} test/databaseTest.cpp)
-    set_target_properties( databaseTest PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_include_directories(
-            databaseTest
             PUBLIC
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-            ${TagLib_INCLUDE_DIRS}
+            common
+            PkgConfig::TagLib
+            Boost::headers
+            Threads::Threads
     )
+
     target_link_libraries(
             databaseTest
-            Threads::Threads
-            ${Boost_LIBRARIES}
-            ${TagLib_LIBRARIES}
-    )
-
-    #
-    # playerCmdl
-    #
-    add_executable( playerCmdl ${PLAYERINTERFACE}
-        ${CMAKE_SOURCE_DIR}/common/Constants.cpp
-        ${CMAKE_SOURCE_DIR}/common/Constants.h
-        ${CMAKE_SOURCE_DIR}/common/logger.cpp
-        ${CMAKE_SOURCE_DIR}/common/logger.h
-        ${CMAKE_SOURCE_DIR}/common/repeattimer.cpp
-        ${CMAKE_SOURCE_DIR}/common/repeattimer.h
-        ${CMAKE_SOURCE_DIR}/common/filesystemadditions.cpp
-        ${CMAKE_SOURCE_DIR}/common/filesystemadditions.h
-        ${CMAKE_SOURCE_DIR}/common/stringmanipulator.cpp
-        ${CMAKE_SOURCE_DIR}/common/stringmanipulator.h
-        ${CMAKE_SOURCE_DIR}/common/base64.cpp
-        ${CMAKE_SOURCE_DIR}/common/base64.h
-        ${CMAKE_SOURCE_DIR}/database/playlist.cpp
-        ${CMAKE_SOURCE_DIR}/database/playlist.h
-        ${CMAKE_SOURCE_DIR}/test/KeyHit.cpp
-        ${CMAKE_SOURCE_DIR}/test/KeyHit.h
-        ${CMAKE_SOURCE_DIR}/test/PlayerCmdl.cpp
-        )
-
-    set_target_properties( playerCmdl PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_compile_options( playerCmdl PUBLIC -O2)
-    target_include_directories(
-            playerCmdl
             PUBLIC
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-            ${GST_INCLUDE_DIRS}
+            database
+            common
+            Boost::headers
+            Threads::Threads
     )
+
     target_link_libraries(
             playerCmdl
+            PRIVATE
+            playerinterface
+            database
+            common
+            Boost::headers
             Threads::Threads
-            ${Boost_LIBRARIES}
-            ${GST_LIBRARIES}
     )
 
-    #
-    # loggerTest
-    #
-    add_executable( loggerTest
-        ${CMAKE_SOURCE_DIR}/common/logger.cpp
-        ${CMAKE_SOURCE_DIR}/common/logger.h
-        ${CMAKE_SOURCE_DIR}/test/loggerTest.cpp
-        )
+    target_link_libraries(loggerTest PUBLIC common)
 
-    set_target_properties( loggerTest PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_compile_options( loggerTest PUBLIC -O0 -g)
-    target_include_directories(
-            loggerTest
-            PUBLIC
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-    )
-
-    #
-    # repeatTimerTeset
-    #
-    add_executable( repeatTimerTest
-        ${CMAKE_SOURCE_DIR}/common/logger.cpp
-        ${CMAKE_SOURCE_DIR}/common/logger.h
-        ${CMAKE_SOURCE_DIR}/common/repeattimer.cpp
-        ${CMAKE_SOURCE_DIR}/common/repeattimer.h
-        ${CMAKE_SOURCE_DIR}/test/repeatTimerTest.cpp
-        )
-    set_target_properties( repeatTimerTest PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_compile_options( repeatTimerTest PUBLIC -O0 -g)
-    target_include_directories(
-            repeatTimerTest
-            PUBLIC
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-    )
     target_link_libraries(
             repeatTimerTest
-            ${Boost_LIBRARIES}
+            PUBLIC
+            common
+            Boost::headers
             Threads::Threads
     )
 
-    #
-    # mpvTest
-    #
-    add_executable( mpvTest
-        ${COMMONCOMPONENTS}
-        ${CMAKE_SOURCE_DIR}/test/mpvTest.cpp
-        )
-    set_target_properties( mpvTest PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_compile_options( mpvTest PUBLIC -O0 -g)
-    target_include_directories(
-            mpvTest
-            PUBLIC
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-    )
     target_link_libraries(
             mpvTest
-            ${Boost_LIBRARIES}
+            PUBLIC
+            common
+            Boost::headers
             Threads::Threads
     )
 
-    #
-    # gstreamer Test
-    #
-    add_executable( gstTest
-        ${COMMONCOMPONENTS}
-        ${CMAKE_SOURCE_DIR}/test/gstTest.cpp
-        )
-    set_target_properties( gstTest PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_compile_options( gstTest PUBLIC -O0 -g)
-    target_include_directories(
-            gstTest
-            PUBLIC
-            ${GST_INCLUDE_DIRS}
-            ${CMAKE_SOURCE_DIR}
-            ${Boost_INCLUDE_DIRS}
-    )
     target_link_libraries(
             gstTest
-            ${GST_LIBRARIES}
-            ${Boost_LIBRARIES}
+            PUBLIC
+            common
+            PkgConfig::GST
+            Boost::headers
             Threads::Threads
     )
 
-
-#
-# url Test
-#
-add_executable( urlTest
-    ${COMMONCOMPONENTS}
-    ${CMAKE_SOURCE_DIR}/test/urlTest.cpp
+    target_link_libraries(
+            urlTest
+            PUBLIC
+            common
+            Boost::headers
+            Threads::Threads
     )
-set_target_properties( urlTest PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-target_compile_options( urlTest PUBLIC -O0 -g)
-target_include_directories(
-        urlTest
-        PUBLIC
-        ${CMAKE_SOURCE_DIR}
-        ${Boost_INCLUDE_DIRS}
-)
-target_link_libraries(
-        urlTest
-        ${Boost_LIBRARIES}
-        Threads::Threads
-)
 
 endif(WITH_ADD)
 
@@ -414,7 +225,7 @@ install(
 )
 
 # cmake -DCMAKE_INSTALL_PREFIX=$OECORE_TARGET_SYSROOT/usr/ ..
-install(TARGETS wpa_generator
+install(TARGETS wpaGenerator
     RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}

--- a/audioserver/CMakeLists.txt
+++ b/audioserver/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(${PROJECT_NAME}
+    PRIVATE
+    audioServer.cpp
+)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,0 +1,27 @@
+target_sources(common
+    PRIVATE
+    Constants.cpp
+    Constants.h
+    logger.h
+    logger.cpp
+    Extractor.h
+    mime_type.cpp
+    mime_type.h
+    NameGenerator.h
+    NameGenerator.cpp
+    urlDecode.h
+    urlDecode.c
+    repeattimer.cpp
+    repeattimer.h
+    filesystemadditions.cpp
+    filesystemadditions.h
+    FileType.h
+    generalPlaylist.h
+    stringmanipulator.cpp
+    stringmanipulator.h
+    albumlist.h
+    hash.cpp
+    hash.h
+    base64.cpp
+    base64.h
+)

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -1,0 +1,16 @@
+target_sources(database
+PRIVATE
+    NameType.h
+    searchitem.h
+    searchaction.h
+    playlist.cpp
+    playlist.h
+    id3repository.cpp
+    id3repository.h
+    playlistcontainer.cpp
+    playlistcontainer.h
+    SimpleDatabase.cpp
+    SimpleDatabase.h
+    songtagreader.cpp
+    songtagreader.h
+)

--- a/extractId3Cover/CMakeLists.txt
+++ b/extractId3Cover/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(mp3CoverExtractor
+PRIVATE
+    saveID3TagPicture.cpp
+)

--- a/id3tagreader/CMakeLists.txt
+++ b/id3tagreader/CMakeLists.txt
@@ -1,0 +1,8 @@
+target_sources(id3tagreader
+    PRIVATE
+        Id3Info.h
+        id3TagReader.cpp
+        id3TagReader.h
+        idtag.cpp
+        idtag.h
+)

--- a/itunesJsonConverter/CMakeLists.txt
+++ b/itunesJsonConverter/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(ituneJsonConverter
+PRIVATE
+    itunesJsonConverter.cpp
+)

--- a/playerinterface/CMakeLists.txt
+++ b/playerinterface/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(playerinterface
+PRIVATE
+    Player.h
+    Player.cpp
+    mpvplayer.h
+    mpvplayer.cpp
+    gstplayer.h
+    gstplayer.cpp
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,41 @@
+target_sources(uniqueNameGenerator
+PRIVATE
+    uniqueNameGenerator.cpp
+)
+
+target_sources(databaseTest
+PRIVATE
+    databaseTest.cpp
+)
+
+target_sources(playerCmdl
+PRIVATE
+    KeyHit.cpp
+    KeyHit.h
+    PlayerCmdl.cpp
+)
+
+target_sources(loggerTest
+PRIVATE
+    loggerTest.cpp
+)
+
+target_sources(repeatTimerTest
+PRIVATE
+    repeatTimerTest.cpp
+)
+
+target_sources(mpvTest
+PRIVATE
+    mpvTest.cpp
+)
+
+target_sources(gstTest
+PRIVATE
+    gstTest.cpp
+)
+
+target_sources(urlTest
+PRIVATE
+    urlTest.cpp
+)

--- a/test/PlayerCmdl.cpp
+++ b/test/PlayerCmdl.cpp
@@ -64,7 +64,7 @@ private:
             break;
         }
         case 'c': {
-            m_player->toogleLoop();
+            m_player->toggleLoop();
             break;
         }
         case 'x': {

--- a/webserver/CMakeLists.txt
+++ b/webserver/CMakeLists.txt
@@ -1,0 +1,19 @@
+target_sources(${PROJECT_NAME}
+PRIVATE
+    Listener.cpp
+    Listener.h
+    sessionhandler.cpp
+    sessionhandler.h
+    Session.cpp
+    Session.h
+    databaseaccess.cpp
+    databaseaccess.h
+    playlistaccess.cpp
+    playlistaccess.h
+    playeraccess.cpp
+    playeraccess.h
+    wifiaccess.cpp
+    wifiaccess.h
+    websocketsession.cpp
+    websocketsession.h
+)

--- a/wifi/CMakeLists.txt
+++ b/wifi/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(${PROJECT_NAME}
+PRIVATE
+    wifi.h
+    wifi.cpp
+)

--- a/wpa_generator/CMakeLists.txt
+++ b/wpa_generator/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(wpaGenerator
+PRIVATE
+    wpa_generator.cpp
+)


### PR DESCRIPTION
I improved your cmake build with following features:
* Use Transitive Usage Requirements see https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#transitive-usage-requirements
* If snc library doesn't exists it will include the lib via cmake `FetchContent`. This needs PR -> https://github.com/yorns/snc/pull/1

+ Fix compile issue :-)